### PR TITLE
Add provider-configuration file for ServiceLocator

### DIFF
--- a/src/main/resources/META-INF/services/liquibase.lockservice.LockService
+++ b/src/main/resources/META-INF/services/liquibase.lockservice.LockService
@@ -1,0 +1,1 @@
+liquibase.lockservice.ext.NoOpLockService


### PR DESCRIPTION
Fix missing provider-configuration file for Liquibase >= 4.0.0

Since Liquibase 4 this extension no longer "just works". An additional provider-configuration file is required for the `java.util.ServiceLocator` (see [Upgrade Guide]) so the NoOpLockService will be found and used.

This PR simply adds the required file so this extension "just works" with newer versions of Liquibase.

This PR does not (yet?) contain a test (which could look like [DisableLiquibaseLockTest]). The fixed problem exists only with Liquibase versions newer than the currently depended. Using different versions for the compile and test scope requires either additional CI configuration or dirty hacks (like this [answer from stackoverflow]). I'm not sure how or whether to proceed here.

[Upgrade Guide]: https://docs.liquibase.com/tools-integrations/extensions/extension-upgrade-guides/lb-4.0-upgrade-guide.html#How_Extension_Classes_are_Configured_and_Found
[answer from stackoverflow]: https://stackoverflow.com/questions/6575742/maven-2-different-dependency-versions-in-test-and-compile#answer-67743309
[DisableLiquibaseLockTest]: https://github.com/openthinclient/openthinclient-manager/blob/65fb65bf63e622015f2263780e8e48b538941416/db/src/test/java/org/openthinclient/db/DisableLiquibaseLockTest.java
