### PR TITLE
Add service descriptor according to https://docs.liquibase.com/tools-…

### DIFF
--- a/src/main/resources/services/liquibase.lockservice.LockService
+++ b/src/main/resources/services/liquibase.lockservice.LockService
@@ -1,0 +1,1 @@
+liquibase.lockservice.ext.NoOpLockService


### PR DESCRIPTION
Liquibase 4.0 and higher requires service descriptor in resources/META-INF/services/liquibase.lockservice.LockService file. Otherwise extension doesn't works. 
Docs: https://docs.liquibase.com/tools-integrations/extensions/extension-upgrade-guides/lb-4.0-upgrade-guide.html