### PR TITLE
feat(release-drafter.yml): add release drafter configuration file

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,53 @@
+
+name-template: 'Support for Liquibase Hibernate Extension v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skipReleaseNotes'
+categories:
+  - title: ':green_book: Notable Changes'
+    labels: 
+      - 'notableChanges'
+  - title: '🚀 New Features'
+    labels:
+      - 'TypeEnhancement'
+      - 'TypeTest'
+  - title: '🐛 Bug Fixes 🛠'
+    labels:
+      - 'TypeBug'
+  - title: '💥 Breaking Changes'
+    labels: 
+      - 'breakingChanges'
+  - title: '🤖 Security Driver and Other Updates'
+    collapse-after: 5
+    labels:
+      - 'sdou'
+      - 'dependencies'
+  - title: '👏 New Contributors'
+    labels:
+      - 'newContributors'  
+       
+  
+change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'patch'
+      - 'bugfix'
+      - 'sdou'
+  default: patch
+template: |
+  ## Changes
+  
+  $CHANGES
+
+  **Full Changelog**: https://github.com/liquibase/liquibase-mongodb/compare/liquibase-mongodb-$PREVIOUS_TAG...liquibase-mongodb-$RESOLVED_VERSION
+


### PR DESCRIPTION
This commit adds a new file `.github/workflows/release-drafter.yml` which contains the configuration for the release drafter GitHub action. The release drafter is responsible for automatically generating release notes based on the labels assigned to pull requests and issues.

The configuration file includes the following settings:
- `name-template`: Specifies the template for the release name.
- `tag-template`: Specifies the template for the release tag.
- `exclude-labels`: Specifies the labels to exclude from the release notes.
- `categories`: Specifies the categories for organizing the release notes.
- `change-template`: Specifies the template for each individual change in the release notes.
- `change-title-escapes`: Specifies the characters to escape in the change titles.
- `version-resolver`: Specifies the labels to use for resolving the version type (major, minor, patch).
- `template`: Specifies the template for the release notes.

The configuration file also includes placeholders for variables such as `$RESOLVED_VERSION`, `$NUMBER`, `$TITLE`, `$AUTHOR`, `$CHANGES`, `$PREVIOUS_TAG`, which will be dynamically replaced with the actual values during the release process.

The full changelog for each release can be found at the provided URL.