### PR TITLE
build: align JUnit under single 6.1.2 version + label GH-Actions Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "sdou"

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
     <properties>
         <liquibase.version>5.0.3</liquibase.version>
-        <junit.version>5.11.3</junit.version>
-        <junit-platform.version>1.11.3</junit-platform.version>
+        <!-- JUnit 6+ aligns all modules (jupiter, vintage, platform) under one version. -->
+        <junit.version>6.1.2</junit.version>
     </properties>
 
     <dependencies>
@@ -46,13 +46,13 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>${junit-platform.version}</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit-platform.version}</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Two small CI/build fixes in one PR.

### JUnit version alignment
JUnit 6 unified all module versions (jupiter, vintage, platform), previously split across the `5.x` and `1.x` schemes. Collapse `junit-platform.version` into a single `junit.version` (6.1.2) so all five JUnit artifacts stay aligned on future bumps. Verified with `mvn test-compile` (BUILD SUCCESS).

Supersedes #174 and #175, which each bumped only one property and left the versions mismatched.

### Dependabot label
The `github-actions` Dependabot entry had no `labels`, so its PRs (e.g. #168) defaulted to `dependencies` — not in the list `label-pr.yml` accepts — and failed the required-labels check. Add `labels: ["sdou"]` to match the `maven` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
